### PR TITLE
set Commodum's genesis entry for testnet v3

### DIFF
--- a/testnet1/genesis.json
+++ b/testnet1/genesis.json
@@ -85,13 +85,13 @@
       "name": "XPRV"
     },
     {
-      "address": "81C27F13E77A99E4436420E400B4E95BCAE2BFE8",
+      "address": "C07EE11A22C853B509105906F7CB902F36056B29",
       "pub_key": {
-        "type": "tendermint/PubKeyEd25519",
-        "value": "5Ob3d3k37IkGigTkU5I7gYQE6r6C2bJ5+3LlcarLF50="
+         "type": "tendermint/PubKeyEd25519",
+         "value": "WIWT1vHJAuJ+WCy0y6U7ZV70U34rtwiSE7QANQn1cKM="
       },
       "power": "10",
-      "name": "Commodum DAO"
+      "name": "Commodum"
     },
     {
       "address": "741382DC9360BF60E9B29A55B279EC65EE8DB195",
@@ -197,7 +197,17 @@
         "ethereum_address": "0x5e6FEDca8A214A0136f7C03F132E9ACCA828f015",
         "info_url": "https://xprv.io/",
         "country": "UK"
-      },
+      }, 
+      "WIWT1vHJAuJ+WCy0y6U7ZV70U34rtwiSE7QANQn1cKM=": {
+	"id": "ea0019f6b89176f709cac4e4aba383cd6f9db6ea4c6ddfa0758fe962442fd8db",
+	"vega_pub_key": "d665ae57018b992105885c3d33ddff5b7d2d0baa2c32147117e460215a31764f",
+	"ethereum_address": "0x323214232ce28C420D91445588e84EFB6B1559E9",
+	"tm_pub_key": "WIWT1vHJAuJ+WCy0y6U7ZV70U34rtwiSE7QANQn1cKM=",
+	"info_url": "https://commodum.io",
+	"country": "UK",
+	"name": "Commodum",
+	"avatar_url": ""
+	},  
       "5Ob3d3k37IkGigTkU5I7gYQE6r6C2bJ5+3LlcarLF50=": {
         "vega_pub_key": "3d56a05886a6117d9939907f3154a397e1f9549b6160478c370360c49b346dd4",
         "ethereum_address": "0x66cC07FE724052893f1DdA588157170DFE03C2A1",


### PR DESCRIPTION
This is an update to the testnet genesis file to update Commodum's validator details after a reconfigure for Vega binaries 0.44.1