### PR TITLE
Set max payout per epoch 9890 VEGA per epoch

### DIFF
--- a/mainnet1/genesis.json
+++ b/mainnet1/genesis.json
@@ -340,6 +340,7 @@
       "market.liquidityProvision.shapes.maxSize": "100",
       "reward.staking.delegation.payoutFraction": "1.0",
       "reward.staking.delegation.maxPayoutPerParticipant": "700000000000000000000",
+      "reward.staking.delegation.maxPayoutPerEpoch": "9890000000000000000000",
       "reward.staking.delegation.payoutDelay": "72h",
       "reward.staking.delegation.delegatorShare": "0.883",
       "reward.staking.delegation.minimumValidatorStake": "3000000000000000000000",

--- a/mainnet1/genesis.json
+++ b/mainnet1/genesis.json
@@ -344,6 +344,7 @@
       "reward.staking.delegation.payoutDelay": "72h",
       "reward.staking.delegation.delegatorShare": "0.883",
       "reward.staking.delegation.minimumValidatorStake": "3000000000000000000000",
+      "reward.staking.delegation.minValidators": "5",
       "reward.staking.delegation.competitionLevel": "3.1",
       "validators.epoch.length": "24h",
       "validators.delegation.minAmount": "100000000000000000",


### PR DESCRIPTION
This is `69,000 VEGA` per week, as intended. 

NB: the `reward.staking.delegation.payoutFraction` is already set to `1.0` with the view that if the network treasury gets funded daily with the intended amount for that day (epoch) then it should be fully paid out. 

Added `reward.staking.delegation.minValidators` as `5`. This is the default but I think it doesn't hurt to have it explicit.