### PR TITLE
chore: Update fairground genesis for incentive

### DIFF
--- a/fairground/genesis.json
+++ b/fairground/genesis.json
@@ -184,7 +184,7 @@
       "market.monitor.price.updateFrequency": "1s",
       "market.stake.target.scalingFactor": "0.1",
       "market.stake.target.timeWindow": "1h0m0s",
-      "market.value.windowLength": "168h0m0s",
+      "market.value.windowLength": "1h0m0s",
       "network.checkpoint.marketFreezeDate": "never",
       "network.checkpoint.networkEndOfLifeDate": "never",
       "network.checkpoint.timeElapsedBetweenCheckpoints": "1m",


### PR DESCRIPTION
Update fairground genesis for next rewards incentive as per suggestion from @davidsiska-vega 

set `market.liquidity.providers.fee.distributionTimeStep` to `0m`
set `market.value.windowLength` to `1h0m0s`