### PR TITLE
Remove outdated contract info

### DIFF
--- a/contracts.md
+++ b/contracts.md
@@ -1,5 +1,5 @@
 
-# Ethereum contracts
+# Ethereum contracts - mainnet
 | Contract               | Description                                                      | Mainnet address                             | Etherscan                                                                               | Source                                                             |
 | ---------------------- | ---------------------------------------------------------------- | --------------------------------------------|:-------------------------------------------------------------------------: | ------------------------------------------------------------------ |
 | Staking bridge         | Staking & delegation of VEGA tokens                              | `0x195064D33f09e0c42cF98E665D9506e0dC17de68`| [🔎](https://etherscan.io/address/0x195064D33f09e0c42cF98E665D9506e0dC17de68) | [Staking_Bridge](https://github.com/vegaprotocol/Staking_Bridge)   |
@@ -12,16 +12,3 @@
 | ∟ VEGA v1 (deprecated) | V1 token, replaced by v2 above                                   | `0xd249b16f61cb9489fe0bb046119a48025545b58a`| [🔎](https://etherscan.io/address/0xd249b16f61cb9489fe0bb046119a48025545b58a) | [Vega_Token](https://github.com/vegaprotocol/vega_token)           |
 
 The addresses above are deployed instances of the contracts. Other deployments may exist - if you deploy to other Ethereum networks and think it would be useful, please create a PR adding a link to the deployment address.
-
-# Ropsten Test tokens
-For Fairground, the first Vega testnet, a number of test tokens were deployed to Ropsten. The addresses are listed below, although they are simply ERC20 tokens that are recognised by the bridge in Fairground. You can use these or deploy your own.
-
-## Testnet Tokens
-| Token Name | Token Address | Etherscan   |
-|:----------:|-------------|:-------------:|
-|    tDAI    | `0x65e92e892Fbb489ea263c8E52bb11D1c9b67C54d`|[🔎](https://ropsten.etherscan.io/address/0x65e92e892Fbb489ea263c8E52bb11D1c9b67C54d) |
-|    tBTC    | `0xc6A622C2bbCA2645f941eDEEE6f2611971b6870c`|[🔎](https://ropsten.etherscan.io/address/0xc6A622C2bbCA2645f941eDEEE6f2611971b6870c) |
-|    tUSDC   | `0xbc2ab6Cdeeff966F8E8fE136460A49e46a72D4b9`|[🔎](https://ropsten.etherscan.io/address/0xbc2ab6Cdeeff966F8E8fE136460A49e46a72D4b9) |
-|    tEURO   | `0x8218996E51a807Caa94B815a8e144fd5229f07A8`|[🔎](https://ropsten.etherscan.io/address/0x8218996E51a807Caa94B815a8e144fd5229f07A8) |
-|    tVOTE   | `0x7e503d51E18bF3d5825682A54B363799D4a8e344`|[🔎](https://ropsten.etherscan.io/address/0x7e503d51E18bF3d5825682A54B363799D4a8e344)   |                         |
-


### PR DESCRIPTION
Removes token/contract info for a testnet network that is no longer available.