### PR TITLE
Update commodum's testnet grpc endpoint

### DIFF
--- a/testnet2/testnet2.toml
+++ b/testnet2/testnet2.toml
@@ -14,7 +14,7 @@ Value = "testnet2"
       "tls://testnet.grpc.vega.xprv.io:443",
       "vega-testnet.nodes.guru:3007",
       "testnet.vega.greenfield.xyz:3007",
-      "vega-testnet-data.commodum.io:3007",
+      "tls://vega-testnet-data-grpc.commodum.io:443",
       "tls://vega-grpc.testnet.lovali.xyz:433",
       "vega-test-data.bharvest.io:3007"
     ]


### PR DESCRIPTION
re-enabling reverse proxy to hide data node