### PR TITLE
fix: correct broken links across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ root@ubuntu-s-4vcpu-8gb-amd-lon1-01:~# data-node node
 
 If everything is working correctly you will be able to access gRPC on port 3007, GraphQL on 3008 and REST on port 3009.
 
-Detailed API docs are available [here](https://docs.fairground.vega.xyz/).
+Detailed API docs are available [here](https://docs.vega.xyz/).
 
 ## Ethereum Event Forwarder
 

--- a/networks.json
+++ b/networks.json
@@ -3,12 +3,12 @@
     "name": "mainnet1",
     "configFileUrl": "https://raw.githubusercontent.com/vegaprotocol/networks/master/mainnet1/mainnet1.toml",
     "explorer": "https://explorer.vega.xyz/",
-    "sha": "155ba02d817ef14c6dcfd1874c0fb9d568414635"
+    "sha": "c428545af9cd29b130ae545f0d244dafaff4b49f"
   },
   {
     "name": "testnet2",
     "configFileUrl": "https://raw.githubusercontent.com/vegaprotocol/networks/master/testnet2/testnet2.toml",
-    "explorer": "https://validator-testnet.explorer.vega.xyz/",
-    "sha": "db1327e72a2cb49bbdc0b1e5b97024e679807700"
+    "explorer": "https://explorer.validators-testnet.vega.rocks/",
+    "sha": "c90a1f3c9b38f5697479edbd213fb74d4eabe115"
   }
 ]

--- a/scripts/generate-json.js
+++ b/scripts/generate-json.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const EXPLORER_URLS = {
   mainnet1: 'https://explorer.vega.xyz/',
   testnet1: 'https://explorer.fairground.wtf/',
-  testnet2: 'https://validator-testnet.explorer.vega.xyz/',
+  testnet2: 'https://explorer.validators-testnet.vega.rocks/',
 }
 
 const run = async () => {

--- a/testnet2/testnet2.toml
+++ b/testnet2/testnet2.toml
@@ -43,6 +43,6 @@ Value = "testnet"
     ]
 
 [Apps]
-  Console = "https://validator-testnet.console.vega.xyz/"
-  Governance = "https://validator-testnet.governance.vega.xyz/"
-  Explorer = "https://validator-testnet.explorer.vega.xyz/"
+  Console = "https://console.validators-testnet.vega.rocks/"
+  Governance = "https://governance.validators-testnet.vega.rocks/"
+  Explorer = "https://explorer.validators-testnet.vega.rocks/"


### PR DESCRIPTION
Explorer for testnet2 has moved. The docs link still works, but is a redirect.

- Fix links
