### PR TITLE
fix: outdated testnet2 app urls

### DIFF
--- a/testnet2/testnet2.toml
+++ b/testnet2/testnet2.toml
@@ -43,6 +43,6 @@ Value = "testnet"
     ]
 
 [Apps]
-  Console = "https://validator-testnet.console.vega.xyz/"
-  Governance = "https://validator-testnet.governance.vega.xyz/"
-  Explorer = "https://validator-testnet.explorer.vega.xyz/"
+  Console = "https://console.validators-testnet.vega.rocks"
+  Governance = "https://governance.validators-testnet.vega.rocks/"
+  Explorer = "https://explorer.validators-testnet.vega.rocks/"


### PR DESCRIPTION
The front end URLs for explorer, governance and console were all outdated. This PR changes the old `.vega.xyz` links to `.vega.rocks` links.

- Update testnet2 app urls