### PR TITLE
feat: add mainnet.community data-node to the mainnet.toml file

### DIFF
--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -25,6 +25,7 @@ Value = "mainnet"
       # !! not passing standard validations
       # "tls://grpc.vega.xprv.io:443",
       "vega.mainnet.stakingcabin.com:3007",
+      "tls://grpc.vega.mainnet.community:443",
     ]
     Retries = 5
   [API.REST]
@@ -45,6 +46,7 @@ Value = "mainnet"
       # !! not passing standard validations
       # "https://vega.xprv.io/datanode",
       "https://vega.mainnet.stakingcabin.com:3008",
+      "https://vega.mainnet.community",
     ]
   [API.GraphQL]
     Hosts = [
@@ -64,6 +66,7 @@ Value = "mainnet"
       # !! not passing standard validations
       # "https://vega.xprv.io/datanode/query",
       "https://vega.mainnet.stakingcabin.com:3008/query",
+      "https://vega.mainnet.community/graphql",
     ]
 
 [Apps]


### PR DESCRIPTION
Tested with the [jeremyletang/check_validator_setup](https://github.com/jeremyletang/check_validator_setup) tool. The results are like below:

```shell

(bots-py3.11) ➜  check_validator_setup git:(master) ✗ cat mainnet_config.json
{
    "validators": [
                {
                        "name": "Mainnet-community",
                        "grpc": "tls://grpc.vega.mainnet.community:443",
                        "gql": "https://vega.mainnet.community/graphql",
                        "rest": "https://vega.mainnet.community"
                }
    ]
}%                                                                                                                                                                
(bots-py3.11) ➜  check_validator_setup git:(master) ✗ go run main.go          
 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (4/4, 20 it/s)        
+-------------------+-------------+-------------+-------------+-------------+
| VALIDATOR         | CORE        | DATANODE    | REST        | GRAPHQL     |
+-------------------+-------------+-------------+-------------+-------------+
| Mainnet-community | 69.189613ms | 29.330381ms | 57.828435ms | 39.267197ms |
+-------------------+-------------+-------------+-------------+-------------+
+-----------+-----+-------+
| VALIDATOR | API | ERROR |
+-----------+-----+-------+
+-----------+-----+-------+
(bots-py3.11) ➜  check_validator_setup git:(master) ✗ 
```