### PR TITLE
Cleanup dead data-nodes in the mainnet

### DIFF
--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -11,7 +11,6 @@ Value = "mainnet"
     Hosts = [
       "vega-data.nodes.guru:3007",
       "vega-data.bharvest.io:3007",
-      "datanode.vega.pathrocknetwork.org:3007",
       "tls://vega-grpc.aurora-edge.com:443",
       "darling.network:3007",
       "tls://grpc.velvet.tm.p2p.org:443",
@@ -25,13 +24,15 @@ Value = "mainnet"
       # "tls://grpc.vega.xprv.io:443",
       "vega.mainnet.stakingcabin.com:3007",
       "tls://grpc.vega.mainnet.community:443",
+
+      # !! subjects not running data-node anymore
+      # "datanode.vega.pathrocknetwork.org:3007",
     ]
     Retries = 5
   [API.REST]
     Hosts = [
       "https://vega-data.nodes.guru:3008",
       "https://vega-data.bharvest.io",
-      "https://datanode.vega.pathrocknetwork.org",
       "https://vega.aurora-edge.com",
       "https://darling.network",
       "https://rest.velvet.tm.p2p.org",
@@ -45,12 +46,14 @@ Value = "mainnet"
       # "https://vega.xprv.io/datanode",
       "https://vega.mainnet.stakingcabin.com:3008",
       "https://vega.mainnet.community",
+
+      # !! subjects not running data-node anymore
+      # "https://datanode.vega.pathrocknetwork.org",
     ]
   [API.GraphQL]
     Hosts = [
       "https://vega-data.nodes.guru:3008/graphql",
       "https://vega-data.bharvest.io/graphql",
-      "https://datanode.vega.pathrocknetwork.org/graphql",
       "https://vega.aurora-edge.com/graphql",
       "https://darling.network/graphql",
       "https://gql.velvet.tm.p2p.org/graphql",
@@ -64,6 +67,9 @@ Value = "mainnet"
       # "https://vega.xprv.io/datanode/query",
       "https://vega.mainnet.stakingcabin.com:3008/query",
       "https://vega.mainnet.community/graphql",
+
+      # !! subjects not running data-node anymore
+      "https://datanode.vega.pathrocknetwork.org/graphql",
     ]
 
 [Apps]

--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -9,6 +9,7 @@ Value = "mainnet"
 [API]
   [API.GRPC]
     Hosts = [
+      "croissant.network:3007",
       "vega-data.nodes.guru:3007",
       "vega-data.bharvest.io:3007",
       "tls://vega-grpc.aurora-edge.com:443",
@@ -29,6 +30,7 @@ Value = "mainnet"
     Retries = 5
   [API.REST]
     Hosts = [
+      "https://croissant.network",
       "https://vega-data.nodes.guru:3008",
       "https://vega-data.bharvest.io",
       "https://vega.aurora-edge.com",
@@ -48,6 +50,7 @@ Value = "mainnet"
     ]
   [API.GraphQL]
     Hosts = [
+      "https://croissant.network/graphql",
       "https://vega-data.nodes.guru:3008/graphql",
       "https://vega-data.bharvest.io/graphql",
       "https://vega.aurora-edge.com/graphql",

--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -18,7 +18,6 @@ Value = "mainnet"
       "vega-mainnet.anyvalid.com:3007",
       # !! not passing vaguer validations
       # "vega-data-mainnet.rockrpc.net:3007",
-      # "vega.greenfield.xyz:3007",
       # !! not passing standard validations
       # "tls://grpc.vega.xprv.io:443",
       "vega.mainnet.stakingcabin.com:3007",
@@ -27,6 +26,7 @@ Value = "mainnet"
       # !! subjects not running data-node anymore
       # "datanode.vega.pathrocknetwork.org:3007",
       # "tls://grpc.velvet.tm.p2p.org:443",
+      # "vega.greenfield.xyz:3007",
     ]
     Retries = 5
   [API.REST]
@@ -36,11 +36,9 @@ Value = "mainnet"
       "https://vega.aurora-edge.com",
       "https://darling.network",
       "https://vega-rest.mainnet.lovali.xyz",
-      "https://graphqlvega.gpvalidator.com",
       "https://vega-mainnet.anyvalid.com",
       # !! not passing vaguer validations
       # "https://vega-data-mainnet.rockrpc.net",
-      # "https://vega.greenfield.xyz",
       # !! not passing standard validations
       # "https://vega.xprv.io/datanode",
       "https://vega.mainnet.stakingcabin.com:3008",
@@ -49,6 +47,8 @@ Value = "mainnet"
       # !! subjects not running data-node anymore
       # "https://datanode.vega.pathrocknetwork.org",
       # "https://rest.velvet.tm.p2p.org",
+      # "https://vega.greenfield.xyz",
+      # "https://graphqlvega.gpvalidator.com",
     ]
   [API.GraphQL]
     Hosts = [
@@ -57,11 +57,9 @@ Value = "mainnet"
       "https://vega.aurora-edge.com/graphql",
       "https://darling.network/graphql",
       "https://vega-query.mainnet.lovali.xyz/graphql",
-      "https://graphqlvega.gpvalidator.com/graphql",
       "https://vega-mainnet.anyvalid.com/graphql",
       # !! not passing vaguer validations
       # "https://vega-data-mainnet.rockrpc.net/graphql",
-      # "https://vega.greenfield.xyz/graphql",
       # !! not passing standard validations
       # "https://vega.xprv.io/datanode/query",
       "https://vega.mainnet.stakingcabin.com:3008/query",
@@ -70,6 +68,8 @@ Value = "mainnet"
       # !! subjects not running data-node anymore
       # "https://datanode.vega.pathrocknetwork.org/graphql",
       # "https://gql.velvet.tm.p2p.org/graphql",
+      # "https://vega.greenfield.xyz/graphql",
+      # "https://graphqlvega.gpvalidator.com/graphql",
     ]
 
 [Apps]

--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -14,12 +14,9 @@ Value = "mainnet"
       "tls://vega-grpc.aurora-edge.com:443",
       "darling.network:3007",
       "vega-grpc.mainnet.lovali.xyz:3007",
-      "grpcvega.gpvalidator.com:3007",
       "vega-mainnet.anyvalid.com:3007",
-      # !! not passing vaguer validations
-      # "vega-data-mainnet.rockrpc.net:3007",
-      # !! not passing standard validations
-      # "tls://grpc.vega.xprv.io:443",
+      "vega-data-mainnet.rockrpc.net:3007",
+      "tls://grpc.vega.xprv.io:443",
       "vega.mainnet.stakingcabin.com:3007",
       "tls://grpc.vega.mainnet.community:443",
 
@@ -27,6 +24,7 @@ Value = "mainnet"
       # "datanode.vega.pathrocknetwork.org:3007",
       # "tls://grpc.velvet.tm.p2p.org:443",
       # "vega.greenfield.xyz:3007",
+      # "grpcvega.gpvalidator.com:3007",
     ]
     Retries = 5
   [API.REST]
@@ -37,10 +35,8 @@ Value = "mainnet"
       "https://darling.network",
       "https://vega-rest.mainnet.lovali.xyz",
       "https://vega-mainnet.anyvalid.com",
-      # !! not passing vaguer validations
-      # "https://vega-data-mainnet.rockrpc.net",
-      # !! not passing standard validations
-      # "https://vega.xprv.io/datanode",
+      "https://vega-data-mainnet.rockrpc.net",
+      "https://vega.xprv.io/datanode",
       "https://vega.mainnet.stakingcabin.com:3008",
       "https://vega.mainnet.community",
 
@@ -58,10 +54,8 @@ Value = "mainnet"
       "https://darling.network/graphql",
       "https://vega-query.mainnet.lovali.xyz/graphql",
       "https://vega-mainnet.anyvalid.com/graphql",
-      # !! not passing vaguer validations
-      # "https://vega-data-mainnet.rockrpc.net/graphql",
-      # !! not passing standard validations
-      # "https://vega.xprv.io/datanode/query",
+      "https://vega-data-mainnet.rockrpc.net/graphql",
+      "https://vega.xprv.io/datanode/query",
       "https://vega.mainnet.stakingcabin.com:3008/query",
       "https://vega.mainnet.community/graphql",
 

--- a/mainnet1/mainnet1.toml
+++ b/mainnet1/mainnet1.toml
@@ -13,7 +13,6 @@ Value = "mainnet"
       "vega-data.bharvest.io:3007",
       "tls://vega-grpc.aurora-edge.com:443",
       "darling.network:3007",
-      "tls://grpc.velvet.tm.p2p.org:443",
       "vega-grpc.mainnet.lovali.xyz:3007",
       "grpcvega.gpvalidator.com:3007",
       "vega-mainnet.anyvalid.com:3007",
@@ -27,6 +26,7 @@ Value = "mainnet"
 
       # !! subjects not running data-node anymore
       # "datanode.vega.pathrocknetwork.org:3007",
+      # "tls://grpc.velvet.tm.p2p.org:443",
     ]
     Retries = 5
   [API.REST]
@@ -35,7 +35,6 @@ Value = "mainnet"
       "https://vega-data.bharvest.io",
       "https://vega.aurora-edge.com",
       "https://darling.network",
-      "https://rest.velvet.tm.p2p.org",
       "https://vega-rest.mainnet.lovali.xyz",
       "https://graphqlvega.gpvalidator.com",
       "https://vega-mainnet.anyvalid.com",
@@ -49,6 +48,7 @@ Value = "mainnet"
 
       # !! subjects not running data-node anymore
       # "https://datanode.vega.pathrocknetwork.org",
+      # "https://rest.velvet.tm.p2p.org",
     ]
   [API.GraphQL]
     Hosts = [
@@ -56,7 +56,6 @@ Value = "mainnet"
       "https://vega-data.bharvest.io/graphql",
       "https://vega.aurora-edge.com/graphql",
       "https://darling.network/graphql",
-      "https://gql.velvet.tm.p2p.org/graphql",
       "https://vega-query.mainnet.lovali.xyz/graphql",
       "https://graphqlvega.gpvalidator.com/graphql",
       "https://vega-mainnet.anyvalid.com/graphql",
@@ -69,7 +68,8 @@ Value = "mainnet"
       "https://vega.mainnet.community/graphql",
 
       # !! subjects not running data-node anymore
-      "https://datanode.vega.pathrocknetwork.org/graphql",
+      # "https://datanode.vega.pathrocknetwork.org/graphql",
+      # "https://gql.velvet.tm.p2p.org/graphql",
     ]
 
 [Apps]


### PR DESCRIPTION
# Changes:
- Added croissant.network data-node
- Removed data-nodes from parties that not willing to run data-nodes

# Testing

## [Vaguer](https://github.com/vegaprotocol/vaguer)

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/257fd01d-1a89-40ce-a256-04ed89829610">

## [Check validator setup](https://github.com/jeremyletang/check_validator_setup)

<img width="867" alt="image" src="https://github.com/user-attachments/assets/22026267-b12b-4c3d-a753-48e9e037bde9">
